### PR TITLE
Notify on new episodes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "files.associations": {
     "**/tsconfig/*.json": "jsonc"
   },
-  "docker.commands.run": "${containerCommand} run --rm ${exposedPorts} ${tag}"
+  "docker.commands.run": "${containerCommand} run --rm ${exposedPorts} ${tag}",
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@acme/db": "workspace:*",
     "@trpc/server": "catalog:",
-    "ansi-escape-sequences": "catalog:",
     "cors": "catalog:",
     "discord.js": "catalog:",
     "dotenv": "catalog:",
@@ -27,7 +26,6 @@
   },
   "devDependencies": {
     "@acme/tsconfig": "workspace:*",
-    "@types/ansi-escape-sequences": "catalog:",
     "@types/cors": "catalog:",
     "@types/node-cron": "catalog:",
     "eslint": "catalog:",

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -52,7 +52,10 @@ const envSchema = z
       .enum(['error', 'warn', 'info', 'verbose', 'debug'])
       .default('info'),
     DATA_DIR: z.string().transform((dir) => path.resolve(dir)),
-    SKIP_STARTUP_DATA_SYNC: z.boolean().default(false),
+    SKIP_STARTUP_DATA_SYNC: z
+      .enum(['0', '1', 'true', 'false'])
+      .default('false')
+      .transform((value) => ['1', 'true'].includes(value.toLowerCase())),
   })
   .transform((obj) => ({
     ...obj,

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -2,9 +2,15 @@ import { config as dotEnvConfig } from 'dotenv'
 import { z } from 'zod'
 import { validate } from 'node-cron'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 dotEnvConfig({
-  path: ['.env.local', '.env.development'],
+  path: ['.env.local', `.env.${process.env.NODE_ENV ?? 'development'}`].map(
+    (filename) => path.resolve(dirname, '..', filename),
+  ),
 })
 
 const envSchema = z

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -59,9 +59,9 @@ const envSchema = z
       .default('info'),
     DATA_DIR: z.string().transform((dir) => path.resolve(dir)),
     SKIP_STARTUP_DATA_SYNC: z
-      .enum(['0', '1', 'true', 'false'])
+      .enum(['0', '1', 'false', 'true'])
       .default('false')
-      .transform((value) => ['1', 'true'].includes(value.toLowerCase())),
+      .transform((value) => ['1', 'true'].includes(value)),
   })
   .transform((obj) => ({
     ...obj,

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -52,6 +52,7 @@ const envSchema = z
       .enum(['error', 'warn', 'info', 'verbose', 'debug'])
       .default('info'),
     DATA_DIR: z.string().transform((dir) => path.resolve(dir)),
+    SKIP_STARTUP_DATA_SYNC: z.boolean().default(false),
   })
   .transform((obj) => ({
     ...obj,

--- a/packages/api/src/model/Media.ts
+++ b/packages/api/src/model/Media.ts
@@ -1,9 +1,15 @@
 import { User } from './User'
 
-export interface Epsiode {
-  season: number
-  episode: number
-  downloadStatus: DownloadStatus
+export interface Season {
+  number: number
+  available: boolean
+  episodes: Record<number, Episode>
+}
+
+export interface Episode {
+  number: number
+  seasonNumber: number
+  available: boolean
 }
 
 export interface DownloadStatus {
@@ -21,7 +27,7 @@ export interface MediaInfo<Type extends 'movie' | 'tv' = 'movie' | 'tv'> {
   overview: string
   image: string
   status: 'Pending' | 'Processing' | 'Available' | 'Blacklisted' | 'Unknown'
-  episodes: Epsiode[]
+  seasons: Type extends 'movie' ? undefined : Record<number, Season>
   downloadStatus: DownloadStatus
   link: string
   requests: Request[]

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -34,7 +34,7 @@ export const postRouter = createTRPCRouter({
   }),
   hook: publicProcedure.mutation(async ({ ctx }) => {
     const { logger } = ctx
-    logger.info('Running media sync hook')
+    logger.info('Checking media updates')
 
     const { getMedia } = mediaService(ctx)
 
@@ -70,6 +70,6 @@ export const postRouter = createTRPCRouter({
       }),
     )
 
-    logger.info('Media sync hook complete')
+    logger.info('Update check complete')
   }),
 })

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -51,25 +51,23 @@ export const postRouter = createTRPCRouter({
     }
 
     await Promise.all(
-      medias
-        .filter((media) => media.id === 3570)
-        .map(async (media) => {
-          const mediaLogger = logger.child({
-            mediaId: `${media.type}/${media.id}`,
+      medias.map(async (media) => {
+        const mediaLogger = logger.child({
+          mediaId: `${media.type}/${media.id}`,
+        })
+        mediaLogger.verbose(`Processing ${media.title}`)
+        const { processMediaUpdate } = mediaService({
+          ...ctx,
+          logger: mediaLogger,
+        })
+        return processMediaUpdate(media)
+          .catch((error) => {
+            mediaLogger.error(error)
           })
-          mediaLogger.verbose(`Processing ${media.title}`)
-          const { processMediaUpdate } = mediaService({
-            ...ctx,
-            logger: mediaLogger,
+          .finally(() => {
+            mediaLogger.verbose(`Done`)
           })
-          return processMediaUpdate(media)
-            .catch((error) => {
-              mediaLogger.error(error)
-            })
-            .finally(() => {
-              mediaLogger.verbose(`Done`)
-            })
-        }),
+      }),
     )
 
     logger.info('Media sync hook complete')

--- a/packages/api/src/router/post.ts
+++ b/packages/api/src/router/post.ts
@@ -25,7 +25,7 @@ export const postRouter = createTRPCRouter({
     await Promise.all(
       medias.map(async (media) => {
         const mediaLogger = logger.child({
-          mediaId: media.id,
+          mediaId: `${media.type}/${media.id}`,
         })
         mediaLogger.verbose(`Processing ${media.title}`)
         const { processMediaUpdate } = mediaService({

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -3,6 +3,17 @@ import cors from 'cors'
 import { appRouter } from './root'
 import { createTRPCContext } from './trpc'
 import { scheduleCron } from './cron'
+import { config } from './config'
+import { createCaller } from './index'
+import { logger } from './logger'
+
+if (!config.SKIP_STARTUP_DATA_SYNC) {
+  const trpc = createCaller(createTRPCContext())
+  await trpc.post.sync().catch((error) => {
+    logger.error('Error running startup data sync:')
+    logger.error(error)
+  })
+}
 
 scheduleCron()
 

--- a/packages/api/src/service/discord.ts
+++ b/packages/api/src/service/discord.ts
@@ -1,4 +1,3 @@
-import ansi from 'ansi-escape-sequences'
 import {
   AttachmentPayload,
   Client,
@@ -44,7 +43,6 @@ type StatusMeta = {
   color: number
   /** png image 1x1 pixel */
   base64: string
-  ansi: keyof typeof ansi.style
 }
 
 function colorFromStatus(status: MediaInfo['status']): StatusMeta {
@@ -54,35 +52,30 @@ function colorFromStatus(status: MediaInfo['status']): StatusMeta {
         color: 0x2ecc71,
         base64:
           'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj0DtT+B8ABQICa3znZ2oAAAAASUVORK5CYII=',
-        ansi: 'green',
       }
     case 'Blacklisted':
       return {
         color: 0xe74c3c,
         base64:
           'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjeO5j8x8ABfwCb6cFtH0AAAAASUVORK5CYII=',
-        ansi: 'red',
       }
     case 'Pending':
       return {
         color: 0xe67e22,
         base64:
           'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjeFan9B8ABloChnlkdVsAAAAASUVORK5CYII=',
-        ansi: 'yellow',
       }
     case 'Processing':
       return {
         color: 0x3498db,
         base64:
           'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjMJlx+z8ABVICp/IuGtoAAAAASUVORK5CYII=',
-        ansi: 'blue',
       }
     default:
       return {
         color: 0x95a5a6,
         base64:
           'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjmLp02X8ABpMC4IYnRY4AAAAASUVORK5CYII=',
-        ansi: 'white',
       }
   }
 }

--- a/packages/api/src/service/discord.ts
+++ b/packages/api/src/service/discord.ts
@@ -1,4 +1,12 @@
-import { Client, Guild } from 'discord.js'
+import ansi from 'ansi-escape-sequences'
+import {
+  AttachmentPayload,
+  Client,
+  Guild,
+  MessageCreateOptions,
+  MessageEditOptions,
+} from 'discord.js'
+import { Episode, MediaInfo, Season } from '../model/Media'
 
 import { config } from '../config'
 
@@ -29,4 +37,138 @@ export function getTextChannel(server: Guild) {
         cause: error,
       })
     })
+}
+
+type StatusMeta = {
+  /** hex rgb number */
+  color: number
+  /** png image 1x1 pixel */
+  base64: string
+  ansi: keyof typeof ansi.style
+}
+
+function colorFromStatus(status: MediaInfo['status']): StatusMeta {
+  switch (status) {
+    case 'Available':
+      return {
+        color: 0x2ecc71,
+        base64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdj0DtT+B8ABQICa3znZ2oAAAAASUVORK5CYII=',
+        ansi: 'green',
+      }
+    case 'Blacklisted':
+      return {
+        color: 0xe74c3c,
+        base64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjeO5j8x8ABfwCb6cFtH0AAAAASUVORK5CYII=',
+        ansi: 'red',
+      }
+    case 'Pending':
+      return {
+        color: 0xe67e22,
+        base64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjeFan9B8ABloChnlkdVsAAAAASUVORK5CYII=',
+        ansi: 'yellow',
+      }
+    case 'Processing':
+      return {
+        color: 0x3498db,
+        base64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjMJlx+z8ABVICp/IuGtoAAAAASUVORK5CYII=',
+        ansi: 'blue',
+      }
+    default:
+      return {
+        color: 0x95a5a6,
+        base64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjmLp02X8ABpMC4IYnRY4AAAAASUVORK5CYII=',
+        ansi: 'white',
+      }
+  }
+}
+
+function statusMessageTemplate(
+  status: MediaInfo['status'],
+  text: string,
+): MessageCreateOptions {
+  return {
+    embeds: [
+      {
+        title: text,
+        color: colorFromStatus(status).color,
+      },
+    ],
+  }
+}
+
+export const templates = {
+  mediaStatus: function (media: MediaInfo): MessageCreateOptions {
+    return statusMessageTemplate(media.status, `Status → ${media.status}`)
+  },
+
+  episodeStatus: function (episode: Episode): MessageCreateOptions {
+    return statusMessageTemplate(
+      episode.available ? 'Available' : 'Unknown',
+      `Episode S${episode.seasonNumber}E${episode.number} → ${
+        episode.available ? 'Available' : 'Unavailable'
+      }`,
+    )
+  },
+
+  seasonStatus: function (season: Season): MessageCreateOptions {
+    return statusMessageTemplate(
+      season.available ? 'Available' : 'Unknown',
+      `Season ${season.number} → ${
+        season.available ? 'Available' : 'Unavailable'
+      }`,
+    )
+  },
+
+  mainMessage: function (
+    media: MediaInfo,
+  ): MessageCreateOptions & MessageEditOptions {
+    const requests = media.requests
+      .map((r) => (r.user.discordId ? `<@${r.user.discordId}>` : r.user.name))
+      .join(' ')
+    const statusText =
+      media.status === 'Processing'
+        ? `Processing — ${(media.downloadStatus.completion * 100).toFixed()}%`
+        : media.status
+
+    return {
+      embeds: [
+        {
+          title: media.title,
+          url: media.link,
+          description: media.overview,
+          thumbnail: {
+            url: media.image,
+          },
+          color: colorFromStatus(media.status).color,
+          fields: requests
+            ? [
+                {
+                  name: '',
+                  value: `*Requested by* ${requests}`,
+                  inline: true,
+                },
+              ]
+            : undefined,
+          footer: {
+            text: statusText,
+            icon_url: 'attachment://status',
+          },
+        },
+      ],
+      files: [
+        {
+          name: 'status',
+          attachment: Buffer.from(
+            colorFromStatus(media.status).base64,
+            'base64',
+          ),
+        } satisfies AttachmentPayload,
+      ],
+    }
+  },
 }

--- a/packages/api/src/service/discord.ts
+++ b/packages/api/src/service/discord.ts
@@ -1,9 +1,9 @@
 import {
   AttachmentPayload,
+  BaseMessageOptions,
   Client,
   Guild,
   MessageCreateOptions,
-  MessageEditOptions,
 } from 'discord.js'
 import { Episode, MediaInfo, Season } from '../model/Media'
 
@@ -95,11 +95,11 @@ function statusMessageTemplate(
 }
 
 export const templates = {
-  mediaStatus: function (media: MediaInfo): MessageCreateOptions {
+  mediaStatus: function (media: MediaInfo): BaseMessageOptions {
     return statusMessageTemplate(media.status, `Status → ${media.status}`)
   },
 
-  episodeStatus: function (episode: Episode): MessageCreateOptions {
+  episodeStatus: function (episode: Episode): BaseMessageOptions {
     return statusMessageTemplate(
       episode.available ? 'Available' : 'Unknown',
       `Episode S${episode.seasonNumber}E${episode.number} → ${
@@ -108,7 +108,7 @@ export const templates = {
     )
   },
 
-  seasonStatus: function (season: Season): MessageCreateOptions {
+  seasonStatus: function (season: Season): BaseMessageOptions {
     return statusMessageTemplate(
       season.available ? 'Available' : 'Unknown',
       `Season ${season.number} → ${
@@ -117,9 +117,7 @@ export const templates = {
     )
   },
 
-  mainMessage: function (
-    media: MediaInfo,
-  ): MessageCreateOptions & MessageEditOptions {
+  mainMessage: function (media: MediaInfo): BaseMessageOptions {
     const requests = media.requests
       .map((r) => (r.user.discordId ? `<@${r.user.discordId}>` : r.user.name))
       .join(' ')

--- a/packages/api/src/service/media.ts
+++ b/packages/api/src/service/media.ts
@@ -83,7 +83,7 @@ export function mediaService({
         fetchSerie(media.tmdbId)
           .then(async (serie) => ({
             ...serie,
-            episodes: await fetchSerieEpisodes(serie.id),
+            episodes: await fetchSerieEpisodes(media.id),
           }))
           .then(fromSeries(users)),
       ),

--- a/packages/api/src/service/media.ts
+++ b/packages/api/src/service/media.ts
@@ -290,7 +290,7 @@ export function mediaService({
 
   function episodeStatusMessagePayload(episode: Episode): MessageCreateOptions {
     return {
-      content: `\`\`\`ansi\nEpisode ${episode.seasonNumber}x${episode.number} → ${ansi.format(
+      content: `\`\`\`ansi\nEpisode S${episode.seasonNumber}E${episode.number} → ${ansi.format(
         episode.available ? 'Available' : 'Unavailable',
         [episode.available ? 'green' : 'red', 'bold'],
       )}\n\`\`\``,
@@ -372,12 +372,13 @@ export function mediaService({
 
     for (const season of Object.values(media.seasons ?? {})) {
       const lastSeason = lastState.seasons?.[season.number]
-      if (season.available && !lastSeason?.available) {
-        const thread = await getThread()
-        await thread.send(seasonStatusMessagePayload(season))
+      if (season.available) {
+        if (!lastSeason?.available) {
+          const thread = await getThread()
+          await thread.send(seasonStatusMessagePayload(season))
+        }
         continue
       }
-      if (season.available) continue
       for (const episode of Object.values(season.episodes)) {
         const lastEpisode = lastSeason?.episodes?.[episode.number]
         if (episode.available && !lastEpisode?.available) {

--- a/packages/api/src/service/media.ts
+++ b/packages/api/src/service/media.ts
@@ -226,7 +226,7 @@ export function mediaService({
     async function makeNewMessage() {
       logger.info(`Creating new discord message`)
       const message = await channel.send(mainMessagePayload(media))
-      logger.verbose(`Created message ${message.id}`)
+      logger.info(`Created message ${message.id}`)
       await db.insert(Media).values({
         jellyseerr_id: media.id,
         type: media.type,
@@ -237,7 +237,7 @@ export function mediaService({
     }
 
     async function updateMessage(message: Message<true>) {
-      logger.verbose(`Updating existing message ${message.id}`)
+      logger.info(`Updating existing message ${message.id}`)
       await message.edit(mainMessagePayload(media))
       await db
         .update(Media)
@@ -352,8 +352,6 @@ export function mediaService({
       return
     }
 
-    logger.verbose(`Creating events`)
-
     // Last state can potentially have missing keys
     const lastState = threadRow.last_state as DeepPartial<MediaInfo>
 
@@ -366,6 +364,7 @@ export function mediaService({
     }
 
     if (lastState.status !== media.status) {
+      logger.info(`Sending status update: media status`)
       const thread = await getThread()
       await thread.send(mediaStatusMessagePayload(media))
     }
@@ -374,6 +373,7 @@ export function mediaService({
       const lastSeason = lastState.seasons?.[season.number]
       if (season.available) {
         if (!lastSeason?.available) {
+          logger.info(`Sending status update: new season`)
           const thread = await getThread()
           await thread.send(seasonStatusMessagePayload(season))
         }
@@ -382,6 +382,7 @@ export function mediaService({
       for (const episode of Object.values(season.episodes)) {
         const lastEpisode = lastSeason?.episodes?.[episode.number]
         if (episode.available && !lastEpisode?.available) {
+          logger.info(`Sending status update: new episode`)
           const thread = await getThread()
           await thread.send(episodeStatusMessagePayload(episode))
         }

--- a/packages/api/src/utilities/deepEquals.ts
+++ b/packages/api/src/utilities/deepEquals.ts
@@ -1,25 +1,3 @@
-export function isPrimitive(obj: unknown) {
-  return obj !== Object(obj)
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isObject(obj: unknown): obj is Record<keyof any, unknown> {
-  return typeof obj === 'object' && obj !== null
-}
-
 export function deepEquals(obj1: unknown, obj2: unknown) {
-  if (obj1 === obj2) return true
-
-  if (isObject(obj1) && isObject(obj2)) {
-    if (Object.keys(obj1).length !== Object.keys(obj2).length) return false
-
-    for (const key in obj1) {
-      if (!(key in obj2)) return false
-      if (!deepEquals(obj1[key], obj2[key])) return false
-    }
-
-    return true
-  }
-
-  return obj1 === obj2
+  return JSON.stringify(obj1) === JSON.stringify(obj2)
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "dev": "drizzle-kit studio",
+    "studio": "drizzle-kit studio",
     "generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",
     "check-types": "tsc"

--- a/packages/db/src/config.ts
+++ b/packages/db/src/config.ts
@@ -7,7 +7,9 @@ const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
 dotEnvConfig({
-  path: path.resolve(dirname, '../.env.development'),
+  path: ['.env.local', `.env.${process.env.NODE_ENV ?? 'development'}`].map(
+    (filename) => path.resolve(dirname, '..', filename),
+  ),
 })
 
 const envSchema = z

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ catalogs:
     '@trpc/server':
       specifier: ^10.45.2
       version: 10.45.2
-    '@types/ansi-escape-sequences':
-      specifier: ^4.0.4
-      version: 4.0.4
     '@types/cors':
       specifier: ^2.8.17
       version: 2.8.17
@@ -84,9 +81,6 @@ catalogs:
     '@vitejs/plugin-react-swc':
       specifier: ^3.5.0
       version: 3.7.0
-    ansi-escape-sequences:
-      specifier: ^6.2.4
-      version: 6.2.4
     cors:
       specifier: ^2.8.5
       version: 2.8.5
@@ -262,9 +256,6 @@ importers:
       '@trpc/server':
         specifier: 'catalog:'
         version: 10.45.2
-      ansi-escape-sequences:
-        specifier: 'catalog:'
-        version: 6.2.4
       cors:
         specifier: 'catalog:'
         version: 2.8.5
@@ -287,9 +278,6 @@ importers:
       '@acme/tsconfig':
         specifier: workspace:*
         version: link:../../configs/tsconfig
-      '@types/ansi-escape-sequences':
-        specifier: 'catalog:'
-        version: 4.0.4
       '@types/cors':
         specifier: 'catalog:'
         version: 2.8.17
@@ -2870,9 +2858,6 @@ packages:
   '@trpc/server@10.45.2':
     resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
 
-  '@types/ansi-escape-sequences@4.0.4':
-    resolution: {integrity: sha512-pyFROz12oSAohhiOAQER+/6rxYgnmr4FYyU3oyuClfd9O9n4+6SBsfC8ZNNtnbRgIgwjDdRbL8i7kvzbN0LVYg==}
-
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -3160,15 +3145,6 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ansi-escape-sequences@6.2.4:
-    resolution: {integrity: sha512-2KJQAG1Nk4Iyu0dJENKXQJE9smEASrpu/E0F7LSnR72tQXngKGLqfRkHbkinjNct5vvAQY4BwQNt+4Tvg73nDQ==}
-    engines: {node: '>=12.17'}
-    peerDependencies:
-      '@75lb/nature': latest
-    peerDependenciesMeta:
-      '@75lb/nature':
-        optional: true
-
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -3214,10 +3190,6 @@ packages:
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
-
-  array-back@6.2.2:
-    resolution: {integrity: sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==}
-    engines: {node: '>=12.17'}
 
   array-buffer-byte-length@1.0.1:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
@@ -8836,8 +8808,6 @@ snapshots:
 
   '@trpc/server@10.45.2': {}
 
-  '@types/ansi-escape-sequences@4.0.4': {}
-
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -9195,10 +9165,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-escape-sequences@6.2.4:
-    dependencies:
-      array-back: 6.2.2
-
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -9237,8 +9203,6 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
-
-  array-back@6.2.2: {}
 
   array-buffer-byte-length@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,14 +21,12 @@ catalog:
   '@trpc/client': ^10.45.2
   '@trpc/react-query': ^10.45.2
   '@trpc/server': ^10.45.2
-  '@types/ansi-escape-sequences': ^4.0.4
   '@types/cors': ^2.8.17
   '@types/node': ^22.13.14
   '@types/node-cron': ^3.0.11
   '@types/react': ^18.3.3
   '@types/react-dom': ^18.3.0
   '@vitejs/plugin-react-swc': ^3.5.0
-  ansi-escape-sequences: ^6.2.4
   cors: ^2.8.5
   discord.js: ^14.18.0
   dotenv: ^16.4.7


### PR DESCRIPTION
- [x] New episodes and seasons will cause an update message. If entire seasons become available all at once, a notification for the season will be made instead.
- [x] The service will now start with a dry run that only updates the database, mainly to prevent message spam on first run or between updates.
  - You can disable this by setting env var `SKIP_STARTUP_DATA_SYNC` to `true`
- [x] Changes event messages so that they display correctly on mobile (no more ansi color magic)
